### PR TITLE
Changed pt-BR short to pt-br

### DIFF
--- a/_pages/pt.html
+++ b/_pages/pt.html
@@ -1,5 +1,5 @@
 ---
 layout: default
 lang: pt-BR
-short: pt
+short: pt-br
 ---


### PR DESCRIPTION
The short version of the Brazillian Portuguese version of the website is "pt". Given that European Portuguese is 100% translated on the [projects' Crowdin](https://crowdin.com/project/jgmd/pt-PT), the short version should be renamed to something like "pt-br" to eliminate redundancies when merging European Portuguese, which should be something like "pt-pt".